### PR TITLE
Add accepted papers and talk to the Publications page

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -3,12 +3,30 @@ layout: page
 title: Publications
 ---
 
-I can also be found on [Google Scholar](https://scholar.google.com/citations?user=Fki0v_UAAAAJ&hl=en). 
+I can also be found on [Google Scholar](https://scholar.google.com/citations?user=Fki0v_UAAAAJ&hl=en).
 
+
+## Conference Publications
+
+1. **Utility-Aware Retrieval for Knowledge-Grounded Multi-Step Agentic Question Answering.**
+   5th International Conference on Computational Modelling, Simulation and Optimization (CMSO 2026), Singapore.
+   *Accepted; to be presented June 2026.*
+
+2. **Temporal Grounding for Agentic Retrieval Augmented Generation over Dynamic Knowledge Bases.**
+   3rd IEEE Technology & Innovation Conference (TIC 2026), Malaysia.
+   *Accepted; to be presented June 2026.*
+
+
+## Talks
+
+* **Your Agent Doesn't Need More Evals, It Needs an Environment.** LLMDay conference, April 2026.
+
+
+## Writing
 
 **[Medium](https://medium.com/@shivasankeerth)**
 
 * [Malaria Detection using Deep Learning](https://medium.com/towards-artificial-intelligence/malaria-detection-using-deep-learning-8fa52839e801)
 * [Exploring few useful functions in the Pytorch Library on Tensors](https://medium.com/towards-data-science/exploring-few-useful-functions-in-the-pytorch-library-on-tensors-d23ce14d142)
 * [Understanding the Universal Approximation Theorem](https://medium.com/towards-artificial-intelligence/understanding-the-universal-approximation-theorem-327ceeed81ee)
-
+</content>


### PR DESCRIPTION
## Summary
Fills out the Publications page, which previously listed only Medium articles.

### Changes (`publications.md`)
- Add a **Conference Publications** section with the two accepted papers:
  - *Utility-Aware Retrieval for Knowledge-Grounded Multi-Step Agentic Question Answering* (CMSO 2026, Singapore)
  - *Temporal Grounding for Agentic Retrieval Augmented Generation over Dynamic Knowledge Bases* (TIC 2026, Malaysia)
  - Both marked "Accepted; to be presented June 2026".
- Add a **Talks** section with the LLMDay talk (April 2026).
- Group the existing Medium articles under a **Writing** heading. Google Scholar link retained.

No em dashes.

https://claude.ai/code/session_01JiRStibvz5WtqdV9MXvKEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiRStibvz5WtqdV9MXvKEZ)_