### PR TITLE
Add YS monogram favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,10 @@
 
   <meta name="author" content="{{ site.author.name }}" />
 
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="{{ '/img/favicon.svg' | prepend: site.baseurl }}" />
+  <link rel="apple-touch-icon" href="{{ '/img/favicon.svg' | prepend: site.baseurl }}" />
+
   {% if page.subtitle %}
   <meta name="description" content="{{ page.subtitle }}">
   {% endif %}

--- a/img/favicon.svg
+++ b/img/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="YS">
+  <defs>
+    <linearGradient id="ys-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2c3e50"/>
+      <stop offset="1" stop-color="#1a252f"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#ys-bg)"/>
+  <text x="32" y="34" text-anchor="middle" dominant-baseline="central"
+        font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-weight="700" font-size="32" letter-spacing="-2.5" fill="#F75305">YS</text>
+</svg>


### PR DESCRIPTION
## Summary
Adds a browser-tab favicon, which the site was missing (the tab showed no icon).

### Changes
- Add `img/favicon.svg` — a stylish **"YS"** monogram: orange (`#F75305`) lettering on a navy gradient rounded square, matching the site's palette.
- Reference it in `_includes/head.html` as `rel="icon"` (SVG) and `apple-touch-icon`, applied across all pages via the shared head include.

### Notes
- SVG favicons are supported by all current browsers (Chrome, Firefox, Edge, Safari 16.4+). No image-conversion tooling was available in the environment to also emit a `.png`/`.ico` fallback; the SVG is sufficient for modern browsers. Happy to add raster fallbacks if you want older-browser coverage.

https://claude.ai/code/session_01JiRStibvz5WtqdV9MXvKEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiRStibvz5WtqdV9MXvKEZ)_